### PR TITLE
Endpoint should accept multiple alternatives

### DIFF
--- a/lib/split/api.rb
+++ b/lib/split/api.rb
@@ -11,7 +11,7 @@ module Split
       experiment = params[:experiment]
       control = params[:control]
       alternatives = params[:alternatives]
-      alternative = ab_test(experiment, control, alternatives)
+      alternative = ab_test(experiment, control, *alternatives)
       MultiJson.encode({:alternative => alternative})
     end
 

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -8,22 +8,27 @@ describe Split::API do
   end
 
   before(:each) { Split.redis.flushall }
-  
+
   describe '/ab_test' do
     it "should respond" do
       get '/ab_test', :experiment => 'text_color', :control => 'red', :alternatives => 'blue'
       last_response.should be_ok
     end
-  
+
+    it 'should accept an array of alternatives' do
+      get '/ab_test', :experiment => 'text_color', :control => 'red', :alternatives => ['blue', 'green', 'yellow']
+      last_response.should be_ok
+    end
+
     it 'should set the correct session variable'
   end
-  
+
   describe '/finished' do
     it "should respond" do
       post '/finished', :experiment => 'text_color'
       last_response.should be_ok
     end
-    
+
     it 'should handle having an empty session'
   end
 end


### PR DESCRIPTION
- Given the [definition](https://github.com/splitrb/split/blob/52ecd67bbe5c28ab85bd2abb48509f14cdbd1f21/lib/split/helper.rb#L5) of the `ab_test` helper, it should
  accept and pass multiple alternatives
